### PR TITLE
Fix: Corrected scoping error for ShaderView06

### DIFF
--- a/Shady/Views/ShaderView06.swift
+++ b/Shady/Views/ShaderView06.swift
@@ -137,7 +137,7 @@ struct ShaderData {
 }
 
 // Displays the shader effect for view 6 of 12 (StarView).
-struct SixthShaderView: View {
+struct ShaderView06: View { // Renamed from SixthShaderView
     // State to control whether the StarView animation is active.
     @State private var isAnimating = true
     


### PR DESCRIPTION
- I renamed the struct `SixthShaderView` to `ShaderView06` in `Shady/Views/ShaderView06.swift`. This resolves a "Cannot find 'ShaderView06' in scope" error that occurred in `ContentView.swift` due to a naming mismatch from the previous refactor.