### PR TITLE
Feature: Add new animated cloud shader (ShaderView13)

### DIFF
--- a/Shady/Shaders/Shaders13.metal
+++ b/Shady/Shaders/Shaders13.metal
@@ -1,0 +1,158 @@
+//
+// Shaders13.metal
+// Shady
+//
+// Metal shaders for generating a drifting clouds effect.
+// Includes a vertex shader for a full-screen quad and a fragment shader
+// that uses Fractal Brownian Motion (fBm) to create cloud patterns.
+//
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+// Structure for vertex shader output, which becomes fragment shader input.
+// Contains clip-space position and texture coordinates.
+struct RasterizerData {
+    float4 position [[position]]; // Output vertex position in clip space.
+    float2 texCoord [[user(texturecoord)]]; // Output texture coordinates.
+};
+
+// Pass-through vertex shader for a full-screen quad.
+// It generates the vertices and texture coordinates for a quad that covers the entire screen.
+[[vertex]]
+RasterizerData cloudVertexShader(uint vertexID [[vertex_id]]) { // vertex_id is the index of the current vertex.
+    RasterizerData out;
+
+    // Predefined full-screen quad vertices (positions in Normalized Device Coordinates - NDC)
+    // and corresponding texture coordinates (UVs).
+    // This forms two triangles (a triangle strip) that cover the screen.
+    float2 positions[4] = {
+        float2(-1.0, -1.0), // Bottom-left (NDC)
+        float2( 1.0, -1.0), // Bottom-right (NDC)
+        float2(-1.0,  1.0), // Top-left (NDC)
+        float2( 1.0,  1.0)  // Top-right (NDC)
+    };
+    float2 texCoords[4] = {
+        float2(0.0, 1.0), // UV for bottom-left
+        float2(1.0, 1.0), // UV for bottom-right
+        float2(0.0, 0.0), // UV for top-left
+        float2(1.0, 0.0)  // UV for top-right
+    };
+
+    // Set the clip-space position for the current vertex.
+    // z = 0.0 (on the near plane), w = 1.0 (no perspective division needed for orthographic projection).
+    out.position = float4(positions[vertexID], 0.0, 1.0);
+    // Pass through the texture coordinate for the current vertex.
+    out.texCoord = texCoords[vertexID];
+    return out;
+}
+
+// --- Noise functions (basic implementation for clouds) ---
+
+// Generates a pseudo-random float value between 0.0 and 1.0 based on a 2D input vector.
+// This is a common simple hash function used in procedural generation.
+float random(float2 p) {
+    // sin and dot products with large numbers create a chaotic, pseudo-random result.
+    // fract() keeps the result in the [0,1) range.
+    return fract(sin(dot(p, float2(12.9898, 78.233))) * 43758.5453);
+}
+
+// Smooth noise function (Value Noise).
+// Interpolates random values at integer grid points to create smoother noise.
+float snoise(float2 uv) {
+    float2 i = floor(uv); // Integer part of uv (grid cell coordinates)
+    float2 f = fract(uv); // Fractional part of uv (position within the grid cell)
+
+    // Apply smoothstep function (f*f*(3.0-2.0*f)) to f for smoother interpolation.
+    // This is equivalent to Ken Perlin's improved noise fade curve (6t^5 - 15t^4 + 10t^3).
+    f = f * f * (3.0 - 2.0 * f);
+
+    // Get random values at the four corners of the grid cell.
+    float a = random(i + float2(0.0, 0.0)); // Bottom-left corner
+    float b = random(i + float2(1.0, 0.0)); // Bottom-right corner
+    float c = random(i + float2(0.0, 1.0)); // Top-left corner
+    float d = random(i + float2(1.0, 1.0)); // Top-right corner
+
+    // Bilinear interpolation of the four corner values.
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+// Fractal Brownian Motion (fBm) for generating natural-looking patterns like clouds.
+// It sums multiple layers (octaves) of noise at different frequencies and amplitudes.
+float fbm(float2 uv, int octaves, float persistence) {
+    float total = 0.0;        // Accumulator for the noise value.
+    float frequency = 1.0;    // Initial frequency.
+    float amplitude = 1.0;    // Initial amplitude.
+    float maxValue = 0.0;     // Used to normalize the result to the [0,1] range.
+
+    // Loop through the octaves.
+    for (int i = 0; i < octaves; i++) {
+        // Add noise at the current frequency and amplitude.
+        total += snoise(uv * frequency) * amplitude;
+        // Accumulate the maximum possible amplitude.
+        maxValue += amplitude;
+        // Reduce amplitude for the next octave (persistence < 1).
+        amplitude *= persistence;
+        // Increase frequency for the next octave (typically doubles).
+        frequency *= 2.0;
+    }
+    // Normalize the total noise value.
+    return total / maxValue;
+}
+
+// --- Fragment Shader for Clouds ---
+
+// Generates the cloud effect.
+// It calculates a sky gradient, then layers animated clouds generated using fbm noise,
+// and finally blends them together.
+[[fragment]]
+float4 cloudFragmentShader(RasterizerData in [[stage_in]], // Input from vertex shader (interpolated texCoord)
+                           constant float2 &resolution [[buffer(0)]], // Viewport resolution (width, height) passed from app
+                           constant float &time [[buffer(1)]])        // Time elapsed, for animation, passed from app
+{
+    float2 uv = in.texCoord; // Normalized texture coordinates [0,1]
+    // Flip Y coordinate if your texture coordinate system has (0,0) at the bottom-left.
+    // Metal's default often has (0,0) at top-left for textures.
+    // For full-screen shaders using texCoord from vertex shader, this depends on how texCoords were defined.
+    // The provided vertex shader maps UVs with (0,0) at top-left, so `1.0 - uv.y` makes (0,0) bottom-left for shader logic.
+    uv.y = 1.0 - uv.y;
+
+    // Calculate sky color: a simple vertical gradient from light blue to a deeper blue.
+    // mix interpolates between two values based on a third (uv.y here).
+    float3 skyColor = mix(float3(0.6, 0.8, 1.0), /*light blue at bottom (uv.y=0)*/
+                          float3(0.3, 0.6, 0.9), /*deeper blue at top (uv.y=1)*/
+                          uv.y);
+
+    // Cloud Generation:
+    // Adjust UV coordinates for clouds to account for aspect ratio, preventing stretching.
+    float2 cloudUV = uv * float2(resolution.x / resolution.y, 1.0);
+    // Animate cloud UVs by adding time-dependent offsets to create a drifting effect.
+    // Different speeds for x and y components give a more natural drift.
+    cloudUV += float2(time * 0.05, time * 0.02);
+
+    // Parameters for fbm clouds:
+    // - cloudUV * 2.0: Input coordinate scaling. Larger values make clouds smaller/denser.
+    // - 5: Number of octaves for fbm. More octaves = more detail (and more computation).
+    // - 0.5: Persistence for fbm. Controls how much amplitude decreases for successive octaves.
+    float cloudCover = 0.5; // Base threshold for cloud visibility. Range [0,1].
+                            // Higher values mean fewer visible clouds as fbm output needs to be higher.
+    float cloudDensity = fbm(cloudUV * 2.0, 5, 0.5);
+
+    // Shape the clouds using smoothstep for softer edges.
+    // This creates a transition zone around the `cloudCover` value.
+    // Essentially, values slightly below `cloudCover` smoothly transition to 0 (transparent),
+    // and values slightly above smoothly transition to 1 (opaque).
+    cloudDensity = smoothstep(cloudCover - 0.1, cloudCover + 0.1, cloudDensity);
+
+    // Define the color of the clouds (e.g., white).
+    float3 cloudColor = float3(1.0, 1.0, 1.0);
+
+    // Blend the sky color with the cloud color based on the calculated cloudDensity.
+    // A cloudOpacity factor can be used to make clouds more or less translucent.
+    float cloudOpacity = 0.8;
+    float3 finalColor = mix(skyColor, cloudColor, cloudDensity * cloudOpacity);
+
+    return float4(finalColor, 1.0); // Output final color with full alpha.
+}

--- a/Shady/Views/ContentView.swift
+++ b/Shady/Views/ContentView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct ContentView: View {
     // State variable to keep track of the current view.
-    // Ranges from 0 to 11 (inclusive), corresponding to 12 different shader views.
+    // Ranges from 0 to 12 (inclusive), corresponding to 13 different shader views.
     @State private var currentViewIndex: Int = 0
 
     var body: some View {
         VStack {
-            // Conditionally display one of the 12 shader views
+            // Conditionally display one of the 13 shader views
             // based on the current value of currentViewIndex.
             if currentViewIndex == 0 {
                 ShaderView01()
@@ -40,13 +40,15 @@ struct ContentView: View {
                 ShaderView11()
             } else if currentViewIndex == 11 {
                 ShaderView12()
+            } else if currentViewIndex == 12 { // New case for ShaderView13
+                ShaderView13()
             }
 
             Button("Next Shader") {
                 // Increment the view index
                 currentViewIndex += 1
-                // If the index reaches 12, reset it to 0 to loop back to the first view
-                if currentViewIndex == 12 {
+                // If the index reaches 13 (for 13 views, 0-12), reset it to 0 to loop back to the first view
+                if currentViewIndex == 13 { // Updated condition for 13 views
                     currentViewIndex = 0
                 }
             }

--- a/Shady/Views/ShaderView13.swift
+++ b/Shady/Views/ShaderView13.swift
@@ -1,0 +1,172 @@
+//
+//  ShaderView13.swift
+//  Shady
+//
+//  Created by Jules on 22/7/24
+//  This file defines the SwiftUI View and Metal rendering setup for the 13th shader effect,
+//  which displays animated, procedurally generated clouds.
+//
+
+import SwiftUI
+import MetalKit
+
+// ShaderView13: The main SwiftUI View for displaying the drifting clouds shader.
+// This view embeds the Metal-rendered content and ensures it ignores safe area
+// and does not display a navigation bar, providing a full-screen experience.
+struct ShaderView13: View {
+    var body: some View {
+        CloudMetalBackgroundView()
+            .edgesIgnoringSafeArea(.all) // Ensure the Metal view extends to screen edges.
+            .navigationBarHidden(true) // Hide navigation bar if this view is part of a NavigationView.
+    }
+}
+
+// CloudMetalBackgroundView: A UIViewRepresentable struct.
+// Its role is to bridge the CloudMetalView (which is a subclass of MTKView, a UIKit component)
+// into the SwiftUI view hierarchy, allowing Metal rendering within a SwiftUI app.
+struct CloudMetalBackgroundView: UIViewRepresentable {
+    // Creates the instance of CloudMetalView that will be managed by this representable.
+    func makeUIView(context: Context) -> CloudMetalView {
+        // Initialize CloudMetalView with the default system Metal device.
+        return CloudMetalView(frame: .zero, device: MTLCreateSystemDefaultDevice())
+    }
+
+    // Updates the underlying CloudMetalView when SwiftUI state changes.
+    // For this version, there are no specific SwiftUI state updates propagated to the Metal view.
+    func updateUIView(_ uiView: CloudMetalView, context: Context) {
+        // No specific updates from SwiftUI state are needed for this basic cloud shader.
+        // If, for example, cloud speed or color were configurable via SwiftUI,
+        // those updates would be passed to `uiView` here.
+    }
+}
+
+// CloudMetalView: An MTKView subclass responsible for rendering the cloud shader.
+// It handles Metal setup, the draw loop, and delegate methods for MTKView.
+class CloudMetalView: MTKView {
+    var commandQueue: MTLCommandQueue!        // Queue for sending commands to the GPU.
+    var pipelineState: MTLRenderPipelineState! // Compiled shaders and pipeline configuration.
+    var time: Float = 0                        // Time uniform, incremented each frame for animation.
+    var resolution: simd_float2 = simd_float2(0, 0) // Stores current drawable size for the shader.
+
+    // Initializer for creating the view programmatically.
+    override init(frame: CGRect, device: MTLDevice?) {
+        super.init(frame: frame, device: device ?? MTLCreateSystemDefaultDevice())
+        commonInit() // Perform common setup tasks.
+    }
+
+    // Initializer for creating the view from a storyboard or XIB (required).
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit() // Perform common setup tasks.
+    }
+
+    // commonInit: Centralized setup logic for Metal and MTKView properties.
+    private func commonInit() {
+        // 1. Set up Metal Device:
+        // Ensure a valid Metal device is available; otherwise, the app cannot render.
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            fatalError("Metal is not supported on this device")
+        }
+        self.device = device // Assign the device to the MTKView.
+
+        // 2. Create Command Queue:
+        // The command queue is used to submit command buffers to the GPU for execution.
+        commandQueue = device.makeCommandQueue()
+
+        // 3. Load Shaders and Create Pipeline State:
+        // Access the default Metal shader library bundled with the app.
+        guard let library = device.makeDefaultLibrary() else {
+            fatalError("Could not load default Metal library. Check if Shaders13.metal is compiled and linked.")
+        }
+        // Load the vertex and fragment shader functions by their names defined in Shaders13.metal.
+        let vertexFunction = library.makeFunction(name: "cloudVertexShader")
+        let fragmentFunction = library.makeFunction(name: "cloudFragmentShader")
+
+        // Create a render pipeline descriptor to configure the rendering pipeline.
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.label = "CloudRenderPipeline" // For debugging.
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        // Set the pixel format for the color attachment (output texture) to match the view's format.
+        pipelineDescriptor.colorAttachments[0].pixelFormat = self.colorPixelFormat // Default is .bgra8Unorm.
+
+        // Create the render pipeline state object from the descriptor.
+        // This compiles the shaders and configures the pipeline for efficient rendering.
+        do {
+            pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        } catch {
+            fatalError("Could not create render pipeline state: \(error)")
+        }
+
+        // 4. Configure MTKView settings:
+        // self.colorPixelFormat is already .bgra8Unorm by default for MTKView.
+        // framebufferOnly = true is an optimization if the rendered texture (framebuffer)
+        // doesn't need to be read from (e.g., for post-processing effects).
+        self.framebufferOnly = true
+        self.preferredFramesPerSecond = 60 // Target frame rate for animations.
+        self.delegate = self // Set this class as the delegate to receive draw callbacks.
+        // enableSetNeedsDisplay = false means the view will redraw continuously at preferredFramesPerSecond.
+        // If true, redraws would only happen when setNeedsDisplay() is called.
+        self.enableSetNeedsDisplay = false
+        // isPaused = false ensures the rendering loop starts immediately upon view creation.
+        self.isPaused = false
+    }
+
+    // MTKViewDelegate method: Called when the MTKView's drawable size (viewport) changes.
+    // This is important for shaders that depend on the aspect ratio or resolution.
+    override func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // Update the resolution uniform with the new size.
+        // This ensures the shader can adapt to orientation changes or window resizing.
+        resolution = simd_float2(Float(size.width), Float(size.height))
+    }
+
+    // MTKViewDelegate method: Called for each frame to be rendered.
+    // This is the main rendering loop.
+    override func draw(in view: MTKView) {
+        // Ensure a drawable (texture to render to), render pass descriptor,
+        // command buffer, and render encoder can be created.
+        guard let drawable = currentDrawable,
+              let renderPassDescriptor = currentRenderPassDescriptor, // Describes attachments for rendering.
+              let commandBuffer = commandQueue.makeCommandBuffer(),   // Buffer for GPU commands.
+              let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+            // If any of these fail, skip rendering for this frame.
+            return
+        }
+        renderEncoder.label = "CloudRenderEncoder" // For debugging in GPU frame captures.
+
+        // Update time uniform for animation.
+        // Incrementing by a fixed step based on preferredFramesPerSecond helps achieve
+        // consistent animation speed regardless of actual frame rate fluctuations.
+        time += 1.0 / Float(self.preferredFramesPerSecond)
+
+        // Set the current render pipeline state.
+        renderEncoder.setRenderPipelineState(pipelineState)
+
+        // Pass uniforms to the fragment shader:
+        // - Resolution (simd_float2) is passed to buffer index 0.
+        renderEncoder.setFragmentBytes(&resolution, length: MemoryLayout<simd_float2>.size, index: 0)
+        // - Time (float) is passed to buffer index 1.
+        renderEncoder.setFragmentBytes(&time, length: MemoryLayout<Float>.size, index: 1)
+
+        // Draw a full-screen quad.
+        // The vertex shader (`cloudVertexShader`) generates 4 vertices for a triangle strip
+        // covering the screen. No separate vertex buffer is needed here.
+        renderEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+
+        // Finalize encoding of rendering commands for this pass.
+        renderEncoder.endEncoding()
+        // Schedule the drawable to be presented after the command buffer is committed.
+        commandBuffer.present(drawable)
+        // Commit the command buffer to the GPU for execution.
+        commandBuffer.commit()
+    }
+}
+
+// Preview provider for ShaderView13, useful for iterative development in Xcode Canvas.
+#if DEBUG
+struct ShaderView13_Previews: PreviewProvider {
+    static var previews: some View {
+        ShaderView13()
+    }
+}
+#endif


### PR DESCRIPTION
- Created `Shady/Shaders/Shaders13.metal` containing a new fragment shader that generates a procedural blue sky with drifting clouds. The clouds are created using Fractal Brownian Motion (fBm) and animated over time.
- Added `Shady/Views/ShaderView13.swift`, which sets up the MetalKit view (`CloudMetalView`) to render the new cloud shader. It passes `time` and `resolution` uniforms for animation and aspect ratio correction.
- Updated `Shady/Views/ContentView.swift` to include `ShaderView13` in the sequence of views. The total number of views is now 13 (indexed 0-12), and the "Next Shader" button loops accordingly.
- Added detailed comments to the new shader and view files to explain their implementation.