### PR TITLE
Fix: Resolve "Method does not override" errors in ShaderView13

### DIFF
--- a/Shady/Views/ShaderView13.swift
+++ b/Shady/Views/ShaderView13.swift
@@ -115,7 +115,7 @@ class CloudMetalView: MTKView, MTKViewDelegate {
 
     // MTKViewDelegate method: Called when the MTKView's drawable size (viewport) changes.
     // This is important for shaders that depend on the aspect ratio or resolution.
-    override func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         // Update the resolution uniform with the new size.
         // This ensures the shader can adapt to orientation changes or window resizing.
         resolution = simd_float2(Float(size.width), Float(size.height))
@@ -123,7 +123,7 @@ class CloudMetalView: MTKView, MTKViewDelegate {
 
     // MTKViewDelegate method: Called for each frame to be rendered.
     // This is the main rendering loop.
-    override func draw(in view: MTKView) {
+    func draw(in view: MTKView) {
         // Ensure a drawable (texture to render to), render pass descriptor,
         // command buffer, and render encoder can be created.
         guard let drawable = currentDrawable,


### PR DESCRIPTION
- Removed the `override` keyword from `mtkView(_:drawableSizeWillChange:)` and `draw(in:)` methods in the `CloudMetalView` class within `Shady/Views/ShaderView13.swift`.
- These methods are implementations of the `MTKViewDelegate` protocol, which `CloudMetalView` explicitly conforms to. Removing `override` addresses the compiler error "Method does not override any method from its superclass" that occurred in this context.